### PR TITLE
Use GitHub issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,3 @@
+Contributing guidelines:
+- Search https://www.npmjs.com and the issue tracker before opening an issue.
+- Succinctly describe what you're looking for and use a descriptive title.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,3 +1,3 @@
 Contributing guidelines:
-- Search https://www.npmjs.com and the issue tracker before opening an issue.
+- Search https://npms.io and the issue tracker before opening an issue.
 - Succinctly describe what you're looking for and use a descriptive title.

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # Module Requests
 
-[Request a JavaScript module](https://github.com/sindresorhus/module-requests/issues/new?body=Contributing%20guidelines%3A%0A-%20Search%20https%3A%2F%2Fwww.npmjs.com%20and%20the%20issue%20tracker%20before%20opening%20an%20issue.%0A-%20Succinctly%20describe%20what%20you're%20looking%20for%20and%20use%20a%20descriptive%20title.) you wish existed or [get ideas for modules](https://github.com/sindresorhus/module-requests/issues).
+[Request a JavaScript module](https://github.com/sindresorhus/module-requests/issues/new) you wish existed or [get ideas for modules](https://github.com/sindresorhus/module-requests/issues).
 
 ![a77b1e625aa3d9739706cfe23888917d](https://cloud.githubusercontent.com/assets/170270/7904248/2152e49c-07f4-11e5-9a45-0eadac04f9d8.gif)


### PR DESCRIPTION
This always displays the template, even when users click on _New issue_ within the _Issues_ tab.